### PR TITLE
Added support for rendering waveform images outside of a view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
   - Added by [Kip Nicol](https://github.com/ospr)
 - Fixed bug which could prevent waveform from fitting new view size if rendering was in progress during a view resize
   - Added by [Kip Nicol](https://github.com/ospr)
-- Fixed bug which caused `waveformViewDidRender()` to not be called after the audio file was loaded
+- Fixed bug which caused `waveformViewDidLoad()` to not be called after the audio file was loaded
   - Added by [Kip Nicol](https://github.com/ospr)
 - Fixed bug which caused subsequent waveform renderings for new audioURLs to never complete if there was an error with a previous render
   - Added by [Kip Nicol](https://github.com/ospr)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,23 @@ All notable changes to this project will be documented in this file.
   - Added by [Kip Nicol](https://github.com/ospr)
 - Fixed waveform rendering for large audio files
   - Added by [Kip Nicol](https://github.com/ospr)
-  
+- Added support for rendering waveform images outside of a view (See `FDWaveformRenderOperation`)
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Added support for rendering linear waveforms
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Added support for changing `wavesColor` and `progressColor` after waveform was rendered
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Added support for updating waveform type and color to iOS Example app.
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed bug which could prevent waveform from fitting new view size if rendering was in progress during a view resize
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed bug which caused `waveformViewDidRender()` to not be called after the audio file was loaded
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed bug which caused subsequent waveform renderings for new audioURLs to never complete if there was an error with a previous render
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed bug which could cause a crash (divide by zero error) if the view's width was 0
+  - Added by [Kip Nicol](https://github.com/ospr)
+
 ---
 
 ## [2.0.0](https://github.com/fulldecent/FDWaveformView/releases/tag/2.0.0)

--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="GzX-4u-840">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -18,11 +18,11 @@
                         <viewControllerLayoutGuide type="bottom" id="01F-59-2xz"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="oh1-vd-YBA">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ip2-HE-aX1">
-                                <rect key="frame" x="0.0" y="20" width="119.5" height="30"/>
+                                <rect key="frame" x="0.0" y="20" width="132.66666666666666" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load AAC">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -33,7 +33,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V6O-ov-C15">
-                                <rect key="frame" x="127.5" y="20" width="120" height="30"/>
+                                <rect key="frame" x="140.66666666666669" y="20" width="132.66666666666669" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load MP3">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -44,7 +44,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QiA-5t-Tep">
-                                <rect key="frame" x="255.5" y="20" width="119.5" height="30"/>
+                                <rect key="frame" x="281.33333333333326" y="20" width="132.66666666666669" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load OGG">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -54,8 +54,35 @@
                                     <action selector="doLoadOGG" destination="GzX-4u-840" eventType="touchUpInside" id="rhB-PI-RJC"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WLG-lH-cUv">
+                                <rect key="frame" x="0.0" y="58" width="203.66666666666666" height="30"/>
+                                <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="7Dv-4V-aqI"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                <state key="normal" title="Randomly set play progress">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="doAnimation" destination="GzX-4u-840" eventType="touchUpInside" id="fb7-NT-Wds"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QDN-fD-Zwd">
+                                <rect key="frame" x="211" y="58" width="203" height="30"/>
+                                <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <state key="normal" title="Randomly set colors">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="doChangeColors" destination="GzX-4u-840" eventType="touchUpInside" id="hy5-t9-gRe"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Eo2-dg-ThD">
-                                <rect key="frame" x="0.0" y="96" width="183.5" height="30"/>
+                                <rect key="frame" x="0.0" y="96" width="203" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Zoom in">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -66,7 +93,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XOT-uC-eqi">
-                                <rect key="frame" x="191.5" y="96" width="183.5" height="30"/>
+                                <rect key="frame" x="211" y="96" width="203" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Zoom out">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -77,7 +104,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AIo-Bv-jmO" userLabel="Linear">
-                                <rect key="frame" x="0.0" y="134" width="183.5" height="30"/>
+                                <rect key="frame" x="0.0" y="134" width="203" height="30"/>
                                 <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Linear">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -88,7 +115,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t25-dP-LU3" userLabel="Logarithmic">
-                                <rect key="frame" x="191.5" y="134" width="183.5" height="30"/>
+                                <rect key="frame" x="211" y="134" width="203" height="30"/>
                                 <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Logarithmic">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -98,19 +125,8 @@
                                     <action selector="doLogarithmic" destination="GzX-4u-840" eventType="touchUpInside" id="8C2-de-x46"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WLG-lH-cUv">
-                                <rect key="frame" x="0.0" y="58" width="375" height="30"/>
-                                <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="Randomly set play progress">
-                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="doAnimation" destination="GzX-4u-840" eventType="touchUpInside" id="fb7-NT-Wds"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C2Y-UB-xTc">
-                                <rect key="frame" x="0.0" y="172" width="375" height="30"/>
+                                <rect key="frame" x="0.0" y="172" width="414" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Run performance profiling">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -121,7 +137,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pHr-84-A7W" customClass="FDWaveformView" customModule="FDWaveformView">
-                                <rect key="frame" x="0.0" y="210" width="375" height="457"/>
+                                <rect key="frame" x="0.0" y="210" width="414" height="526"/>
                                 <color key="backgroundColor" red="0.99811935424804688" green="0.92034381628036499" blue="0.90713727474212646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="wavesColor">
@@ -139,19 +155,22 @@
                             <constraint firstItem="AIo-Bv-jmO" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="9KE-Xv-0oY"/>
                             <constraint firstItem="t25-dP-LU3" firstAttribute="top" secondItem="AIo-Bv-jmO" secondAttribute="top" id="BMs-8H-mOR"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="top" secondItem="Ip2-HE-aX1" secondAttribute="top" id="EP2-Bz-Vr6"/>
-                            <constraint firstAttribute="trailing" secondItem="WLG-lH-cUv" secondAttribute="trailing" id="HHp-cp-GGI"/>
                             <constraint firstItem="C2Y-UB-xTc" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="HpT-w6-iSA"/>
                             <constraint firstItem="Eo2-dg-ThD" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="Kke-ES-oXY"/>
                             <constraint firstItem="Eo2-dg-ThD" firstAttribute="width" secondItem="XOT-uC-eqi" secondAttribute="width" id="LBw-T0-4UD"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="width" secondItem="Ip2-HE-aX1" secondAttribute="width" id="LWw-hq-qY8"/>
                             <constraint firstItem="pHr-84-A7W" firstAttribute="top" secondItem="C2Y-UB-xTc" secondAttribute="bottom" constant="8" id="Npi-VG-9Hy"/>
                             <constraint firstItem="V6O-ov-C15" firstAttribute="leading" secondItem="Ip2-HE-aX1" secondAttribute="trailing" constant="8" id="OPB-Vh-njT"/>
+                            <constraint firstAttribute="trailing" secondItem="QDN-fD-Zwd" secondAttribute="trailing" id="QTd-XL-REq"/>
                             <constraint firstItem="Eo2-dg-ThD" firstAttribute="top" secondItem="WLG-lH-cUv" secondAttribute="bottom" constant="8" id="SQN-bP-TFX"/>
+                            <constraint firstItem="QDN-fD-Zwd" firstAttribute="leading" secondItem="WLG-lH-cUv" secondAttribute="trailing" constant="8" id="SmM-To-9dW"/>
                             <constraint firstItem="AIo-Bv-jmO" firstAttribute="width" secondItem="t25-dP-LU3" secondAttribute="width" id="TpO-pG-ZgS"/>
                             <constraint firstItem="XOT-uC-eqi" firstAttribute="top" secondItem="Eo2-dg-ThD" secondAttribute="top" id="UYM-th-ZWm"/>
+                            <constraint firstItem="WLG-lH-cUv" firstAttribute="height" secondItem="QDN-fD-Zwd" secondAttribute="height" id="V1j-L5-9JC"/>
                             <constraint firstItem="01F-59-2xz" firstAttribute="top" secondItem="pHr-84-A7W" secondAttribute="bottom" id="VQx-0k-2h0"/>
                             <constraint firstAttribute="trailing" secondItem="t25-dP-LU3" secondAttribute="trailing" id="XcT-QX-Vg4"/>
                             <constraint firstItem="pHr-84-A7W" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="ZNn-L4-LJb"/>
+                            <constraint firstItem="QDN-fD-Zwd" firstAttribute="width" secondItem="WLG-lH-cUv" secondAttribute="width" id="cfr-Vg-qXg"/>
                             <constraint firstItem="WLG-lH-cUv" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="g3y-aI-M8l"/>
                             <constraint firstItem="C2Y-UB-xTc" firstAttribute="top" secondItem="AIo-Bv-jmO" secondAttribute="bottom" constant="8" id="gW5-tE-o5r"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="leading" secondItem="V6O-ov-C15" secondAttribute="trailing" constant="8" id="hUB-FB-37u"/>
@@ -162,6 +181,7 @@
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="width" secondItem="V6O-ov-C15" secondAttribute="width" id="lII-fH-R24"/>
                             <constraint firstItem="t25-dP-LU3" firstAttribute="leading" secondItem="AIo-Bv-jmO" secondAttribute="trailing" constant="8" id="lPo-HC-P0r"/>
                             <constraint firstItem="Ip2-HE-aX1" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="oQN-9n-qZO"/>
+                            <constraint firstItem="QDN-fD-Zwd" firstAttribute="top" secondItem="WLG-lH-cUv" secondAttribute="top" id="qhO-6Z-Krt"/>
                             <constraint firstItem="AIo-Bv-jmO" firstAttribute="top" secondItem="Eo2-dg-ThD" secondAttribute="bottom" constant="8" id="y5V-dz-TNg"/>
                         </constraints>
                     </view>
@@ -172,6 +192,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5tX-dp-6bC" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="136.80000000000001" y="138.98050974512745"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -106,23 +106,23 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AIo-Bv-jmO" userLabel="Linear">
                                 <rect key="frame" x="0.0" y="134" width="203" height="30"/>
                                 <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="Linear">
-                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="doLinear" destination="GzX-4u-840" eventType="touchUpInside" id="Dfw-LG-KKA"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t25-dP-LU3" userLabel="Logarithmic">
-                                <rect key="frame" x="211" y="134" width="203" height="30"/>
-                                <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Logarithmic">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <action selector="doLogarithmic" destination="GzX-4u-840" eventType="touchUpInside" id="8C2-de-x46"/>
+                                    <action selector="doLogarithmic" destination="GzX-4u-840" eventType="touchUpInside" id="2Ev-Xe-X0A"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t25-dP-LU3" userLabel="Logarithmic">
+                                <rect key="frame" x="211" y="134" width="203" height="30"/>
+                                <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Linear">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="doLinear" destination="GzX-4u-840" eventType="touchUpInside" id="t8d-KS-hFP"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C2Y-UB-xTc">
@@ -186,6 +186,8 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="linearButton" destination="t25-dP-LU3" id="A6s-ss-HvR"/>
+                        <outlet property="logarithmicButton" destination="AIo-Bv-jmO" id="suU-1L-G4Z"/>
                         <outlet property="playButton" destination="oh1-vd-YBA" id="b9j-po-y99"/>
                         <outlet property="waveform" destination="pHr-84-A7W" id="Cbo-cG-3Zd"/>
                     </connections>

--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="16A320" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="GzX-4u-840">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="GzX-4u-840">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,15 +21,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pHr-84-A7W" customClass="FDWaveformView" customModule="FDWaveformView">
-                                <color key="backgroundColor" red="0.99811935424804688" green="0.92034381628036499" blue="0.90713727474212646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="wavesColor">
-                                        <color key="value" red="0.17254901959999999" green="0.50980392159999999" blue="0.78823529410000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ip2-HE-aX1">
+                                <rect key="frame" x="0.0" y="20" width="119.5" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load AAC">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -37,6 +33,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V6O-ov-C15">
+                                <rect key="frame" x="127.5" y="20" width="120" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load MP3">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -47,6 +44,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QiA-5t-Tep">
+                                <rect key="frame" x="255.5" y="20" width="119.5" height="30"/>
                                 <color key="backgroundColor" red="0.98823529409999999" green="0.37647058820000001" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Load OGG">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -57,6 +55,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Eo2-dg-ThD">
+                                <rect key="frame" x="0.0" y="96" width="183.5" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Zoom in">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -67,6 +66,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XOT-uC-eqi">
+                                <rect key="frame" x="191.5" y="96" width="183.5" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Zoom out">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -76,7 +76,30 @@
                                     <action selector="doZoomOut" destination="GzX-4u-840" eventType="touchUpInside" id="AYs-Ev-ApW"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AIo-Bv-jmO" userLabel="Linear">
+                                <rect key="frame" x="0.0" y="134" width="183.5" height="30"/>
+                                <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Linear">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="doLinear" destination="GzX-4u-840" eventType="touchUpInside" id="Dfw-LG-KKA"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t25-dP-LU3" userLabel="Logarithmic">
+                                <rect key="frame" x="191.5" y="134" width="183.5" height="30"/>
+                                <color key="backgroundColor" red="0.9165864587" green="0.89184486870000002" blue="0.27463445069999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Logarithmic">
+                                    <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="doLogarithmic" destination="GzX-4u-840" eventType="touchUpInside" id="8C2-de-x46"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WLG-lH-cUv">
+                                <rect key="frame" x="0.0" y="58" width="375" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Randomly set play progress">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -87,6 +110,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C2Y-UB-xTc">
+                                <rect key="frame" x="0.0" y="172" width="375" height="30"/>
                                 <color key="backgroundColor" red="0.91658645868301392" green="0.89184486865997314" blue="0.27463445067405701" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Run performance profiling">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -96,34 +120,49 @@
                                     <action selector="doRunPerformanceProfile" destination="GzX-4u-840" eventType="touchUpInside" id="qKf-b0-xNq"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pHr-84-A7W" customClass="FDWaveformView" customModule="FDWaveformView">
+                                <rect key="frame" x="0.0" y="210" width="375" height="457"/>
+                                <color key="backgroundColor" red="0.99811935424804688" green="0.92034381628036499" blue="0.90713727474212646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="wavesColor">
+                                        <color key="value" red="0.17254901959999999" green="0.50980392159999999" blue="0.78823529410000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.93609845638275146" green="0.93607044219970703" blue="0.93608629703521729" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="Eo2-dg-ThD" secondAttribute="trailing" id="0h3-Y1-yc0"/>
+                            <constraint firstItem="XOT-uC-eqi" firstAttribute="leading" secondItem="Eo2-dg-ThD" secondAttribute="trailing" constant="8" id="1Ig-n7-rNu"/>
                             <constraint firstItem="WLG-lH-cUv" firstAttribute="top" secondItem="Ip2-HE-aX1" secondAttribute="bottom" constant="8" id="4ZM-7Q-VFH"/>
                             <constraint firstAttribute="trailing" secondItem="QiA-5t-Tep" secondAttribute="trailing" id="5mM-3f-3p7"/>
                             <constraint firstAttribute="trailing" secondItem="pHr-84-A7W" secondAttribute="trailing" id="8LR-eU-l1V"/>
+                            <constraint firstItem="AIo-Bv-jmO" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="9KE-Xv-0oY"/>
+                            <constraint firstItem="t25-dP-LU3" firstAttribute="top" secondItem="AIo-Bv-jmO" secondAttribute="top" id="BMs-8H-mOR"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="top" secondItem="Ip2-HE-aX1" secondAttribute="top" id="EP2-Bz-Vr6"/>
                             <constraint firstAttribute="trailing" secondItem="WLG-lH-cUv" secondAttribute="trailing" id="HHp-cp-GGI"/>
                             <constraint firstItem="C2Y-UB-xTc" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="HpT-w6-iSA"/>
-                            <constraint firstItem="XOT-uC-eqi" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="KdZ-Dj-KcD"/>
                             <constraint firstItem="Eo2-dg-ThD" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="Kke-ES-oXY"/>
+                            <constraint firstItem="Eo2-dg-ThD" firstAttribute="width" secondItem="XOT-uC-eqi" secondAttribute="width" id="LBw-T0-4UD"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="width" secondItem="Ip2-HE-aX1" secondAttribute="width" id="LWw-hq-qY8"/>
                             <constraint firstItem="pHr-84-A7W" firstAttribute="top" secondItem="C2Y-UB-xTc" secondAttribute="bottom" constant="8" id="Npi-VG-9Hy"/>
                             <constraint firstItem="V6O-ov-C15" firstAttribute="leading" secondItem="Ip2-HE-aX1" secondAttribute="trailing" constant="8" id="OPB-Vh-njT"/>
                             <constraint firstItem="Eo2-dg-ThD" firstAttribute="top" secondItem="WLG-lH-cUv" secondAttribute="bottom" constant="8" id="SQN-bP-TFX"/>
+                            <constraint firstItem="AIo-Bv-jmO" firstAttribute="width" secondItem="t25-dP-LU3" secondAttribute="width" id="TpO-pG-ZgS"/>
+                            <constraint firstItem="XOT-uC-eqi" firstAttribute="top" secondItem="Eo2-dg-ThD" secondAttribute="top" id="UYM-th-ZWm"/>
                             <constraint firstItem="01F-59-2xz" firstAttribute="top" secondItem="pHr-84-A7W" secondAttribute="bottom" id="VQx-0k-2h0"/>
+                            <constraint firstAttribute="trailing" secondItem="t25-dP-LU3" secondAttribute="trailing" id="XcT-QX-Vg4"/>
                             <constraint firstItem="pHr-84-A7W" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="ZNn-L4-LJb"/>
                             <constraint firstItem="WLG-lH-cUv" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="g3y-aI-M8l"/>
+                            <constraint firstItem="C2Y-UB-xTc" firstAttribute="top" secondItem="AIo-Bv-jmO" secondAttribute="bottom" constant="8" id="gW5-tE-o5r"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="leading" secondItem="V6O-ov-C15" secondAttribute="trailing" constant="8" id="hUB-FB-37u"/>
                             <constraint firstAttribute="trailing" secondItem="XOT-uC-eqi" secondAttribute="trailing" id="hba-mb-hKR"/>
                             <constraint firstItem="Ip2-HE-aX1" firstAttribute="top" secondItem="C8T-P3-aco" secondAttribute="bottom" id="jvf-Da-oMt"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="top" secondItem="V6O-ov-C15" secondAttribute="top" id="kbm-7d-0tI"/>
                             <constraint firstAttribute="trailing" secondItem="C2Y-UB-xTc" secondAttribute="trailing" id="kmU-rv-w1H"/>
                             <constraint firstItem="QiA-5t-Tep" firstAttribute="width" secondItem="V6O-ov-C15" secondAttribute="width" id="lII-fH-R24"/>
+                            <constraint firstItem="t25-dP-LU3" firstAttribute="leading" secondItem="AIo-Bv-jmO" secondAttribute="trailing" constant="8" id="lPo-HC-P0r"/>
                             <constraint firstItem="Ip2-HE-aX1" firstAttribute="leading" secondItem="oh1-vd-YBA" secondAttribute="leading" id="oQN-9n-qZO"/>
-                            <constraint firstItem="XOT-uC-eqi" firstAttribute="top" secondItem="Eo2-dg-ThD" secondAttribute="bottom" constant="8" id="tBI-Dm-XLR"/>
-                            <constraint firstItem="C2Y-UB-xTc" firstAttribute="top" secondItem="XOT-uC-eqi" secondAttribute="bottom" constant="8" id="yaM-Qf-2VN"/>
+                            <constraint firstItem="AIo-Bv-jmO" firstAttribute="top" secondItem="Eo2-dg-ThD" secondAttribute="bottom" constant="8" id="y5V-dz-TNg"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -122,9 +122,6 @@ extension ViewController: FDWaveformViewDelegate {
         UIView.animate(withDuration: 0.25, animations: {() -> Void in
             waveformView.alpha = 1.0
         })
-        
-        let data = UIImagePNGRepresentation(waveformView.imageView.image!)!
-        try! data.write(to: URL(fileURLWithPath: "/Users/kip/Desktop/real_output.png"))
     }
     
     func waveformViewWillLoad(_ waveformView: FDWaveformView) {

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -87,6 +87,14 @@ class ViewController: UIViewController {
         self.waveform.audioURL = url
     }
     
+    @IBAction func doLinear() {
+        self.waveform.waveformType = .linear
+    }
+    
+    @IBAction func doLogarithmic() {
+        self.waveform.waveformType = .logarithmic
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         let thisBundle = Bundle(for: type(of: self))

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -13,6 +13,8 @@ import FDWaveformView
 class ViewController: UIViewController {
     @IBOutlet weak var waveform: FDWaveformView!
     @IBOutlet var playButton: UIView!
+    @IBOutlet weak var logarithmicButton: UIButton!
+    @IBOutlet weak var linearButton: UIButton!
     
     fileprivate var startRendering = Date()
     fileprivate var endRendering = Date()
@@ -89,10 +91,12 @@ class ViewController: UIViewController {
     
     @IBAction func doLinear() {
         self.waveform.waveformType = .linear
+        updateWaveformTypeButtons()
     }
     
     @IBAction func doLogarithmic() {
         self.waveform.waveformType = .logarithmic
+        updateWaveformTypeButtons()
     }
     
     @IBAction func doChangeColors() {
@@ -116,6 +120,19 @@ class ViewController: UIViewController {
         self.waveform.doesAllowScrubbing = true
         self.waveform.doesAllowStretch = true
         self.waveform.doesAllowScroll = true
+        updateWaveformTypeButtons()
+    }
+    
+    func updateWaveformTypeButtons() {
+        let (selectedButton, nonSelectedButton): (UIButton, UIButton) = {
+            switch self.waveform.waveformType {
+            case .linear: return (self.linearButton, self.logarithmicButton)
+            case .logarithmic: return (self.logarithmicButton, self.linearButton)
+            }
+        }()
+        selectedButton.layer.borderColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.25).cgColor
+        selectedButton.layer.borderWidth = 2
+        nonSelectedButton.layer.borderWidth = 0
     }
 }
 

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -114,6 +114,9 @@ extension ViewController: FDWaveformViewDelegate {
         UIView.animate(withDuration: 0.25, animations: {() -> Void in
             waveformView.alpha = 1.0
         })
+        
+        let data = UIImagePNGRepresentation(waveformView.imageView.image!)!
+        try! data.write(to: URL(fileURLWithPath: "/Users/kip/Desktop/real_output.png"))
     }
     
     func waveformViewWillLoad(_ waveformView: FDWaveformView) {

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -95,6 +95,15 @@ class ViewController: UIViewController {
         self.waveform.waveformType = .logarithmic
     }
     
+    @IBAction func doChangeColors() {
+        let randomColor: () -> (UIColor) = {
+            return UIColor(red: CGFloat(drand48()), green: CGFloat(drand48()), blue: CGFloat(drand48()), alpha: 1)
+        }
+        
+        self.waveform.wavesColor = randomColor()
+        self.waveform.progressColor = randomColor()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         let thisBundle = Bundle(for: type(of: self))

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -651,7 +651,7 @@ final public class FDWaveformRenderOperation: Operation {
             guard
                 let (samples, sampleMax) = sliceAsset(withRange: sampleRange, andDownsampleTo: targetSamples),
                 let image = plotLogGraph(samples, maximumValue: sampleMax, zeroValue: format.type.floorValue)
-            else { return nil }
+                else { return nil }
             
             return image
         }()

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -664,6 +664,7 @@ final public class FDWaveformRenderOperation: Operation {
         
         guard
             !slice.isEmpty,
+            targetSamples > 0,
             let reader = try? AVAssetReader(asset: audioContext.asset)
             else { return nil }
         

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -32,7 +32,6 @@ open class FDWaveformView: UIView {
             delegate?.waveformViewWillLoad?(self)
             
             // TODO: weak self here?
-            // TODO: need to cancel previous loads? Can use nsoperation with block to cancel?
             FDAudioContext.load(fromAudioURL: audioURL) { audioContext in
                 DispatchQueue.main.async {
                     if audioContext == nil {
@@ -421,11 +420,6 @@ final public class FDAudioContext {
     }
 }
 
-// TODO: ++++++++++++++ Consider having a separate class to load the audio file? And that's passed in here?
-//       Or passed into the render function? Although that will still have the same issue where there is shared
-//       state between render calls.
-//       What we need is some way to turn these into discrete operations or tasks that are only run once and are cancellable.
-//       How long does it take to get the duration? If it's not long it's not a big deal to load the asset every time, right?
 final public class FDWaveformRenderOperation: Operation {
     
     // TODO: document and clean up
@@ -436,7 +430,6 @@ final public class FDWaveformRenderOperation: Operation {
     public var imageSize: CGSize = .zero
     public var wavesColor: UIColor = .black
 
-    // TODO: need to set these three below when rendering
     /// Drawing more pixels than shown to get antialiasing, 1.0 = no overdraw, 2.0 = twice as many pixels
     fileprivate var horizontalTargetOverdraw: CGFloat = 3.0
     
@@ -539,7 +532,6 @@ final public class FDWaveformRenderOperation: Operation {
         var channelCount = 1
         let formatDesc = audioContext.assetTrack.formatDescriptions
         for item in formatDesc {
-            // TODO: handle error here
             guard let fmtDesc = CMAudioFormatDescriptionGetStreamBasicDescription(item as! CMAudioFormatDescription) else { return nil }    // TODO: Can the forced downcast in here be safer?
             channelCount = Int(fmtDesc.pointee.mChannelsPerFrame)
         }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -174,6 +174,10 @@ open class FDWaveformView: UIView {
         }
     }
     
+    private var desiredImageScale: CGFloat {
+        return window?.screen.scale ?? UIScreen.main.scale
+    }
+    
     //TODO RENAME
     fileprivate func minMaxX<T: Comparable>(_ x: T, min: T, max: T) -> T {
         return x < min ? min : x > max ? max : x
@@ -275,7 +279,7 @@ open class FDWaveformView: UIView {
         if cachedSampleRange.upperBound > minMaxX(zoomEndSamples + Int(CGFloat(cachedSampleRange.count) * horizontalMaximumBleed), min: 0, max: totalSamples) {
             return true
         }
-        if image.scale != UIScreen.main.scale {
+        if image.scale != desiredImageScale {
             return true
         }
         if image.size.width < frame.width * CGFloat(horizontalMinimumOverdraw) {
@@ -339,7 +343,7 @@ open class FDWaveformView: UIView {
         let widthInPixels = floor(frame.width * horizontalTargetOverdraw)
         let heightInPixels = frame.height * horizontalTargetOverdraw
         let imageSize = CGSize(width: widthInPixels, height: heightInPixels)
-        let renderFormat = FDWaveformRenderFormat(wavesColor: .black, scale: UIScreen.main.scale, noiseFloor: noiseFloor)
+        let renderFormat = FDWaveformRenderFormat(wavesColor: .black, scale: desiredImageScale, noiseFloor: noiseFloor)
         
         let waveformRenderOperation = FDWaveformRenderOperation(audioContext: audioContext, imageSize: imageSize, sampleRange: renderSampleRange, format: renderFormat) { image in
             DispatchQueue.main.async {

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -328,9 +328,6 @@ open class FDWaveformView: UIView {
 
         print("rendering")
         
-        renderingInProgress = true
-        delegate?.waveformViewWillRender?(self)
-        
         let displayRange = zoomEndSamples - zoomStartSamples
         guard displayRange > 0 else { return }
 
@@ -347,17 +344,22 @@ open class FDWaveformView: UIView {
                 self.waveformImage = image
                 self.cachedSampleRange = (image != nil) ? renderSampleRange : nil
                 self.renderingInProgress = false
+                self.waveformRenderOperation = nil
                 self.setNeedsLayout()
                 self.delegate?.waveformViewDidRender?(self)
             }
         }
-        self.waveformRenderOperation = waveformRenderOperation
         // TODO: set other values here or require a context to be passed in
         waveformRenderOperation.sampleRange = renderSampleRange
         waveformRenderOperation.imageSize = CGSize(width: widthInPixels, height: heightInPixels)
         waveformRenderOperation.horizontalTargetOverdraw = horizontalTargetOverdraw
         waveformRenderOperation.verticalTargetOverdraw = verticalTargetOverdraw
         waveformRenderOperation.noiseFloor = noiseFloor
+        
+        self.waveformRenderOperation = waveformRenderOperation
+        renderingInProgress = true
+        delegate?.waveformViewWillRender?(self)
+
         waveformRenderOperation.start()
     }
 }
@@ -460,6 +462,7 @@ final public class FDWaveformRenderOperation: Operation {
         self.completionBlock = { [weak self] in
             guard let `self` = self else { return }
             self.completionHandler(self.renderedImage)
+            self.renderedImage = nil
         }
     }
     

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -375,7 +375,6 @@ open class FDWaveformView: UIView {
         case .notDirty(let cancelInProgressRenderOperation):
             if cancelInProgressRenderOperation {
                 inProgressWaveformRenderOperation = nil
-                // TODO: when cancelled, does the waveform show up again? Or is it not a problem because the audio file hasn't change? Say if we go from linear to log?
             }
         }
 

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -33,6 +33,8 @@ open class FDWaveformView: UIView {
             
             FDAudioContext.load(fromAudioURL: audioURL) { audioContext in
                 DispatchQueue.main.async {
+                    guard self.audioURL == audioContext?.audioURL else { return }
+                    
                     if audioContext == nil {
                         NSLog("FDWaveformView failed to load URL: \(audioURL)")
                     }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -561,7 +561,7 @@ final public class FDWaveformRenderOperation: Operation {
             return image
         }()
         
-        print("image: \(image!), scale: \(image!.scale)")
+        print("image: \(image?.description ?? "nil"), scale: \(image?.scale.description ?? "nil")")
         
         finish(with: image)
     }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -784,7 +784,7 @@ final public class FDWaveformRenderOperation: Operation {
             y: 1 / format.scale) // Scale context to account for scaling applied to image
         context.setShouldAntialias(false)
         context.setAlpha(1.0)
-        context.setLineWidth(0.5)
+        context.setLineWidth(1.0 / format.scale)
         context.setStrokeColor(format.wavesColor.cgColor)
         
         

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -637,10 +637,13 @@ final public class FDWaveformRenderOperation: Operation {
     }
     
     private func render() {
-        guard !sampleRange.isEmpty else {
-            finish(with: nil)
-            return
-        }
+        guard
+            !sampleRange.isEmpty,
+            imageSize.width > 0, imageSize.height > 0
+            else {
+                finish(with: nil)
+                return
+            }
         
         let targetSamples = Int(imageSize.width * format.scale)
         

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -359,12 +359,19 @@ open class FDWaveformView: UIView {
     }
 }
 
+/// Holds audio information used for building waveforms
 final public class FDAudioContext {
     
+    /// The audio asset URL used to load the context
     public let audioURL: URL
     
+    /// Total number of samples in loaded asset
     fileprivate let totalSamples: Int
+    
+    /// Loaded asset
     fileprivate let asset: AVAsset
+    
+    // Loaded assetTrack
     fileprivate let assetTrack: AVAssetTrack
     
     private init(audioURL: URL, totalSamples: Int, asset: AVAsset, assetTrack: AVAssetTrack) {
@@ -407,23 +414,35 @@ final public class FDAudioContext {
     }
 }
 
+/// Format options for FDWaveformRenderOperation
 public struct FDWaveformRenderFormat {
     
     /// The color of the waveform
     public var wavesColor = UIColor.black
     
-    fileprivate var noiseFloor: CGFloat = -50.0
+    /// The "zero" level (in dB)
+    public var noiseFloor: CGFloat = -50.0
 }
 
+/// Operation used for rendering waveform images
 final public class FDWaveformRenderOperation: Operation {
     
-    // TODO: document and clean up
+    /// The audio context used to build the waveform
     public let audioContext: FDAudioContext
+    
+    ///  Handler called when the rendering has completed. nil UIImage indicates that there was an error during processing.
     private let completionHandler: (UIImage?) -> ()
 
-    public let format: FDWaveformRenderFormat
+    /// Size of waveform image to render
     public let imageSize: CGSize
+    
+    /// Range of samples within audio asset to build waveform for
     public let sampleRange: CountableRange<Int>
+    
+    /// Format of waveform image
+    public let format: FDWaveformRenderFormat
+    
+    // MARK: - NSOperation Overrides
     
     public override var isAsynchronous: Bool { return true }
     
@@ -433,13 +452,16 @@ final public class FDWaveformRenderOperation: Operation {
     private var _isFinished = false
     public override var isFinished: Bool { return _isFinished }
     
+    // MARK: - Private
+    
+    /// Final rendered image. Used to hold image for completionHandler.
     private var renderedImage: UIImage?
     
     public init(audioContext: FDAudioContext, imageSize: CGSize, sampleRange: CountableRange<Int>? = nil, format: FDWaveformRenderFormat = FDWaveformRenderFormat(), completionHandler: @escaping (_ image: UIImage?) -> ()) {
         self.audioContext = audioContext
-        self.format = format
         self.imageSize = imageSize
         self.sampleRange = sampleRange ?? 0..<audioContext.totalSamples
+        self.format = format
         self.completionHandler = completionHandler
         
         super.init()
@@ -470,6 +492,7 @@ final public class FDWaveformRenderOperation: Operation {
         
         renderedImage = image
         
+        // completionBlock called automatically by NSOperation after these values change
         willChangeValue(forKey: "isExecuting")
         willChangeValue(forKey: "isFinished")
         _isExecuting = false

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -30,7 +30,7 @@ open class FDWaveformView: UIView {
             }
 
             loadingInProgress = true
-            delegate?.waveformViewWillLoad?(self)// tODO: will need to hook into renderer for this properly
+            delegate?.waveformViewWillLoad?(self)
             
             // TODO: weak self here?
             // TODO: need to cancel previous loads? Can use nsoperation with block to cancel?

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -640,6 +640,8 @@ final public class FDWaveformRenderTask {
             return nil
         }
         
+        UIGraphicsEndImageContext()
+        
         return image
 
         // TODO: handle the progress image differently?

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -184,7 +184,7 @@ open class FDWaveformView: UIView {
     }
 
     /// View for rendered waveform
-    lazy fileprivate var imageView: UIImageView = {
+    lazy public var imageView: UIImageView = {
         let retval = UIImageView(frame: CGRect.zero)
         retval.contentMode = .scaleToFill
         retval.tintColor = self.wavesColor
@@ -275,16 +275,16 @@ open class FDWaveformView: UIView {
         if cachedSampleRange.upperBound > minMaxX(zoomEndSamples + Int(CGFloat(cachedSampleRange.count) * horizontalMaximumBleed), min: 0, max: totalSamples) {
             return true
         }
-        if image.size.width < frame.width * UIScreen.main.scale * CGFloat(horizontalMinimumOverdraw) {
+        if image.size.width < frame.width * CGFloat(horizontalMinimumOverdraw) {
             return true
         }
-        if image.size.width > frame.width * UIScreen.main.scale * CGFloat(horizontalMaximumOverdraw) {
+        if image.size.width > frame.width * CGFloat(horizontalMaximumOverdraw) {
             return true
         }
-        if image.size.height < frame.height * UIScreen.main.scale * CGFloat(verticalMinimumOverdraw) {
+        if image.size.height < frame.height * CGFloat(verticalMinimumOverdraw) {
             return true
         }
-        if image.size.height > frame.height * UIScreen.main.scale * CGFloat(verticalMaximumOverdraw) {
+        if image.size.height > frame.height * CGFloat(verticalMaximumOverdraw) {
             return true
         }
         return false
@@ -333,12 +333,12 @@ open class FDWaveformView: UIView {
         let renderStartSamples = minMaxX(zoomStartSamples - Int(CGFloat(displayRange) * horizontalTargetBleed), min: 0, max: totalSamples)
         let renderEndSamples = minMaxX(zoomEndSamples + Int(CGFloat(displayRange) * horizontalTargetBleed), min: 0, max: totalSamples)
         let renderSampleRange = renderStartSamples..<renderEndSamples
-        let widthInPixels = floor(frame.width * UIScreen.main.scale * horizontalTargetOverdraw)
-        let heightInPixels = frame.height * UIScreen.main.scale * horizontalTargetOverdraw
+        let widthInPixels = floor(frame.width * horizontalTargetOverdraw)
+        let heightInPixels = frame.height * horizontalTargetOverdraw
         let imageSize = CGSize(width: widthInPixels, height: heightInPixels)
-        let renderFormat = FDWaveformRenderFormat(wavesColor: .black, noiseFloor: noiseFloor)
+        let renderFormat = FDWaveformRenderFormat(wavesColor: .black, scale: UIScreen.main.scale, noiseFloor: noiseFloor)
         
-        let waveformRenderOperation = FDWaveformRenderOperation(audioContext: audioContext, imageSize: imageSize, sampleRange: renderSampleRange) { image in
+        let waveformRenderOperation = FDWaveformRenderOperation(audioContext: audioContext, imageSize: imageSize, sampleRange: renderSampleRange, format: renderFormat) { image in
             DispatchQueue.main.async {
                 self.renderForCurrentAssetFailed = (image == nil)
                 print("done")
@@ -419,6 +419,8 @@ public struct FDWaveformRenderFormat {
     
     /// The color of the waveform
     public var wavesColor = UIColor.black
+    
+    public var scale: CGFloat = UIScreen.main.scale
     
     /// The "zero" level (in dB)
     public var noiseFloor: CGFloat = -50.0
@@ -507,14 +509,19 @@ final public class FDWaveformRenderOperation: Operation {
             return
         }
         
+//        let imageHeight = imageSize.height * format.scale
+        let imageWidth = Int(imageSize.width * format.scale)
+        
         let image: UIImage? = {
             guard
-                let (samples, sampleMax) = sliceAsset(withRange: sampleRange, andDownsampleTo: Int(imageSize.width)),
-                let image = plotLogGraph(samples, maximumValue: sampleMax, zeroValue: self.format.noiseFloor, imageHeight: self.imageSize.height)
+                let (samples, sampleMax) = sliceAsset(withRange: sampleRange, andDownsampleTo: imageWidth),
+                let image = plotLogGraph(samples, maximumValue: sampleMax, zeroValue: self.format.noiseFloor)
             else { return nil }
             
             return image
         }()
+        
+        print("image: \(image!), scale: \(image!.scale)")
         
         finish(with: image)
     }
@@ -550,11 +557,22 @@ final public class FDWaveformRenderOperation: Operation {
         }
 
         var sampleMax = format.noiseFloor
-        let samplesPerPixel = max(1, channelCount * slice.count / targetSamples)
-        let filter = [Float](repeating: 1.0 / Float(samplesPerPixel), count: samplesPerPixel)
+        
+        let sliceTotalSamples = channelCount * slice.count
+//        let firstSamplesCount = (sliceTotalSamples / (targetSamples - 1)) * (targetSamples - 1)
+//        let samplesPerPixel = firstSamplesCount / (targetSamples - 1)
+        
+//        print("firstSamplesCount: \(firstSamplesCount), samplesPerPixel: \(samplesPerPixel)")
+        
+        let lowerSamplesPerPixel = max(1, channelCount * slice.count / targetSamples)
+        let sampleRemainder = sliceTotalSamples % targetSamples
+        let filter = [Float]()//(repeating: 1.0 / Float(samplesPerPixel), count: samplesPerPixel)
 
         var outputSamples = [CGFloat]()
         var sampleBuffer = Data()
+        
+        var totalSampleCount = 0
+        var sampleRemainderBucketCount = 0
 
         // 16-bit samples
         reader.startReading()
@@ -574,11 +592,29 @@ final public class FDWaveformRenderOperation: Operation {
             CMBlockBufferGetDataPointer(readBuffer, 0, &readBufferLength, nil, &readBufferPointer)
             sampleBuffer.append(UnsafeBufferPointer(start: readBufferPointer, count: readBufferLength))
             CMSampleBufferInvalidate(readSampleBuffer)
+            
+            totalSampleCount += readBufferLength / 2
 
+//            let samplesPerPixel: Int
+//            if sampleRemainderBucketCount > sampleRemainder {
+//                samplesPerPixel = 44
+//            }
+//            else {
+//                samplesPerPixel = 45
+//            }
+            
             let totalSamples = sampleBuffer.count / MemoryLayout<Int16>.size
-            let downSampledLength = totalSamples / samplesPerPixel
-            let samplesToProcess = downSampledLength * samplesPerPixel
+           
+//            let downSampledLength = totalSamples / samplesPerPixel
+//            let samplesToProcess = downSampledLength * samplesPerPixel
 
+            let (samplesToProcess, downSampledLength) = test(totalCurrentSamples: totalSamples,
+                                                             lowerSamplesPerPixel: lowerSamplesPerPixel,
+                                                             remainder: sampleRemainder,
+                                                             currentRemained: &sampleRemainderBucketCount)
+            let samplesPerPixel = samplesToProcess / downSampledLength
+//            sampleRemainderBucketCount += downSampledLength
+            
             guard samplesToProcess > 0 else { continue }
             
             processSamples(fromData: &sampleBuffer,
@@ -587,7 +623,7 @@ final public class FDWaveformRenderOperation: Operation {
                            samplesToProcess: samplesToProcess,
                            downSampledLength: downSampledLength,
                            samplesPerPixel: samplesPerPixel,
-                           filter: filter)
+                           filter2: filter)
         }
         
         // Process the remaining samples at the end which didn't fit into samplesPerPixel
@@ -605,12 +641,14 @@ final public class FDWaveformRenderOperation: Operation {
                            samplesToProcess: samplesToProcess,
                            downSampledLength: downSampledLength,
                            samplesPerPixel: samplesPerPixel,
-                           filter: filter)
+                           filter2: filter)
         }
         
         // if (reader.status == AVAssetReaderStatusFailed || reader.status == AVAssetReaderStatusUnknown)
         // Something went wrong. Handle it.
         if reader.status == .completed {
+            print("totalSampleCount \(totalSampleCount), expected sample count: \(channelCount * slice.count)")
+            print("outputSampleCount: \(outputSamples.count), expected target samples: \(targetSamples)")
             return (outputSamples, sampleMax)
         } else {
             print("FDWaveformRenderOperation failed to read audio: \(reader.error)")
@@ -618,7 +656,72 @@ final public class FDWaveformRenderOperation: Operation {
         }
     }
     
-    func processSamples(fromData sampleBuffer: inout Data, sampleMax: inout CGFloat, outputSamples: inout [CGFloat], samplesToProcess: Int, downSampledLength: Int, samplesPerPixel: Int, filter: [Float]) {
+    func test(totalCurrentSamples: Int, lowerSamplesPerPixel: Int, remainder: Int, currentRemained: inout Int) -> (samplesToProcess: Int, downsampleCount: Int) {
+
+        let samplesPerPixel: Int = 44
+        let totalSamplesToProcess: Int = totalCurrentSamples
+        
+        // TODO: >= here?
+//        if currentRemained >= remainder {
+//            samplesPerPixel = lowerSamplesPerPixel
+//            totalSamplesToProcess = totalCurrentSamples
+//        }
+//        else {
+//            samplesPerPixel = lowerSamplesPerPixel + 1
+//            
+//            let potentialDownsampleCount = totalCurrentSamples / lowerSamplesPerPixel
+//            
+//            // TODO: >= here?
+//            if currentRemained + potentialDownsampleCount >= remainder {
+//                totalSamplesToProcess = (remainder - currentRemained) * samplesPerPixel
+//            }
+//            else {
+//                totalSamplesToProcess = totalCurrentSamples
+//            }
+//            
+//            
+//        }
+        
+        let samplesToProcess = (totalSamplesToProcess / samplesPerPixel) * samplesPerPixel
+        let downsample = samplesToProcess / samplesPerPixel
+
+        print("downsample: \(downsample), samplesToProcess: \(samplesToProcess)")
+
+        currentRemained += downsample
+        
+        return (samplesToProcess, downsample)
+        
+//        if currentRemained >= remainder {
+//            let samplesPerPixel = lowerSamplesPerPixel
+//            let samplesToProcess = (totalCurrentSamples / samplesPerPixel) * samplesPerPixel
+//            let downsample = samplesToProcess / samplesPerPixel
+//            return (samplesToProcess, downsample)
+//        }
+//        
+//        let samplesPerPixel = lowerSamplesPerPixel + 1
+//        var samplesToProcess = (totalCurrentSamples / samplesPerPixel) * samplesPerPixel
+//        var downsample = samplesToProcess / samplesPerPixel
+//
+//        var changed: Bool = false
+//        if currentRemained + downsample > remainder {
+//            let diff = remainder - currentRemained
+//           
+//            downsample = diff
+//            samplesToProcess = downsample * samplesPerPixel
+//            
+//            changed = true
+//        }
+//        
+//        currentRemained += downsample
+//        
+//        print("downsample: \(downsample), samplesToProcess: \(samplesToProcess), changed: \(changed)")
+//        
+//        return (samplesToProcess, downsample)
+    }
+    
+    func processSamples(fromData sampleBuffer: inout Data, sampleMax: inout CGFloat, outputSamples: inout [CGFloat], samplesToProcess: Int, downSampledLength: Int, samplesPerPixel: Int, filter2: [Float]) {
+    
+        let filter = [Float](repeating: 1.0 / Float(samplesPerPixel), count: samplesPerPixel)
         sampleBuffer.withUnsafeBytes { (samples: UnsafePointer<Int16>) in
             var processingBuffer = [Float](repeating: 0.0, count: samplesToProcess)
             
@@ -653,6 +756,9 @@ final public class FDWaveformRenderOperation: Operation {
                 return element
             }
             
+            print("samplesPerPixel: \(samplesPerPixel), samples to process: \(samplesToProcess), downsample length: \(downSampledDataCG.count)")
+//            print("remainder? \(samplesToProcess % downSampledLength )")
+            
             // Remove processed samples
             sampleBuffer.removeFirst(samplesToProcess * MemoryLayout<Int16>.size)
             
@@ -661,32 +767,39 @@ final public class FDWaveformRenderOperation: Operation {
     }
 
     // TODO: switch to a synchronous function that paints onto a given context? (for issue #2)
-    func plotLogGraph(_ samples: [CGFloat], maximumValue max: CGFloat, zeroValue min: CGFloat, imageHeight: CGFloat) -> UIImage? {
+    func plotLogGraph(_ samples: [CGFloat], maximumValue max: CGFloat, zeroValue min: CGFloat) -> UIImage? {
         guard !isCancelled else { return nil }
         
-        let imageSize = CGSize(width: CGFloat(samples.count), height: imageHeight)
-        UIGraphicsBeginImageContext(imageSize)
+        print("samples \(samples)")
+        
+        UIGraphicsBeginImageContextWithOptions(imageSize, false, format.scale)
         defer { UIGraphicsEndImageContext() }
         guard let context = UIGraphicsGetCurrentContext() else {
             NSLog("FDWaveformView failed to get graphics context")
             return nil
         }
+//        context.scaleBy(x: (imageSize.width) / CGFloat(samples.count), //(((imageSize.width * format.scale) / CGFloat(samples.count)) / format.scale),
+//                        y: 1 / format.scale) // Scale context to account for scaling applied to image
+        context.scaleBy(x: 1 / format.scale, //(((imageSize.width * format.scale) / CGFloat(samples.count)) / format.scale),
+            y: 1 / format.scale) // Scale context to account for scaling applied to image
         context.setShouldAntialias(false)
         context.setAlpha(1.0)
-        context.setLineWidth(1.0)
+        context.setLineWidth(0.5)
         context.setStrokeColor(format.wavesColor.cgColor)
-
+        
+        
         let sampleDrawingScale: CGFloat
         if max == min {
             sampleDrawingScale = 0
         } else {
-            sampleDrawingScale = imageHeight / 2 / (max - min)
+            sampleDrawingScale = (imageSize.height * format.scale) / 2 / (max - min)
         }
-        let verticalMiddle = imageHeight / 2
+        let verticalMiddle = (imageSize.height * format.scale) / 2
         for (x, sample) in samples.enumerated() {
             let height = (sample - min) * sampleDrawingScale
-            context.move(to: CGPoint(x: CGFloat(x), y: verticalMiddle - height))
-            context.addLine(to: CGPoint(x: CGFloat(x), y: verticalMiddle + height))
+            context.move(to: CGPoint(x: CGFloat(x), y: (verticalMiddle - height)))
+            context.addLine(to: CGPoint(x: CGFloat(x), y: (verticalMiddle + height)))
+
             context.strokePath();
         }
         guard let image = UIGraphicsGetImageFromCurrentImageContext() else {

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -31,7 +31,6 @@ open class FDWaveformView: UIView {
             loadingInProgress = true
             delegate?.waveformViewWillLoad?(self)
             
-            // TODO: weak self here?
             FDAudioContext.load(fromAudioURL: audioURL) { audioContext in
                 DispatchQueue.main.async {
                     if audioContext == nil {
@@ -335,7 +334,7 @@ open class FDWaveformView: UIView {
         let renderEndSamples = minMaxX(zoomEndSamples + Int(CGFloat(displayRange) * horizontalTargetBleed), min: 0, max: totalSamples)
         let renderSampleRange = renderStartSamples..<renderEndSamples
         let widthInPixels = floor(frame.width * UIScreen.main.scale * horizontalTargetOverdraw)
-        let heightInPixels = frame.height * UIScreen.main.scale * horizontalTargetOverdraw // TODO: Vertical target overdraw?
+        let heightInPixels = frame.height * UIScreen.main.scale * horizontalTargetOverdraw
         let imageSize = CGSize(width: widthInPixels, height: heightInPixels)
         let renderFormat = FDWaveformRenderFormat(wavesColor: .black, noiseFloor: noiseFloor)
         
@@ -528,7 +527,6 @@ final public class FDWaveformRenderOperation: Operation {
         }
 
         var sampleMax = format.noiseFloor
-        // TODO: bad things happen if target samples is 0
         let samplesPerPixel = max(1, channelCount * slice.count / targetSamples)
         let filter = [Float](repeating: 1.0 / Float(samplesPerPixel), count: samplesPerPixel)
 

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -679,16 +679,6 @@ final public class FDWaveformRenderOperation: Operation {
         UIGraphicsEndImageContext()
         
         return image
-
-        // TODO: handle the progress image differently?
-//        let drawRect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
-//        context.setFillColor(progressColor.cgColor)
-//        UIRectFillUsingBlendMode(drawRect, .sourceAtop)
-//        guard let tintedImage = UIGraphicsGetImageFromCurrentImageContext() else {
-//            NSLog("FDWaveformView failed to get tinted image from context")
-//            return
-//        }
-//        UIGraphicsEndImageContext()
     }
 }
 

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -223,7 +223,7 @@ open class FDWaveformView: UIView {
     }
 
     /// View for rendered waveform
-    lazy public var imageView: UIImageView = {
+    lazy fileprivate var imageView: UIImageView = {
         let retval = UIImageView(frame: CGRect.zero)
         retval.contentMode = .scaleToFill
         retval.tintColor = self.wavesColor

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -548,6 +548,7 @@ public struct FDWaveformRenderFormat {
     /// The color of the waveform
     public var wavesColor = UIColor.black
     
+    /// The scale factor to apply to the rendered image (usually the current screen's scale)
     public var scale: CGFloat = UIScreen.main.scale
 }
 

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -648,7 +648,7 @@ final public class FDWaveformRenderOperation: Operation {
         let image: UIImage? = {
             guard
                 let (samples, sampleMax) = sliceAsset(withRange: sampleRange, andDownsampleTo: targetSamples),
-                let image = plotLogGraph(samples, maximumValue: sampleMax, zeroValue: format.type.floorValue)
+                let image = plotWaveformGraph(samples, maximumValue: sampleMax, zeroValue: format.type.floorValue)
                 else { return nil }
             
             return image
@@ -798,7 +798,7 @@ final public class FDWaveformRenderOperation: Operation {
     }
 
     // TODO: switch to a synchronous function that paints onto a given context? (for issue #2)
-    func plotLogGraph(_ samples: [CGFloat], maximumValue max: CGFloat, zeroValue min: CGFloat) -> UIImage? {
+    func plotWaveformGraph(_ samples: [CGFloat], maximumValue max: CGFloat, zeroValue min: CGFloat) -> UIImage? {
         guard !isCancelled else { return nil }
         
         let imageSize = CGSize(width: CGFloat(samples.count) / format.scale,

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -565,9 +565,6 @@ final public class FDWaveformRenderOperation: Operation {
     /// The audio context used to build the waveform
     public let audioContext: FDAudioContext
     
-    ///  Handler called when the rendering has completed. nil UIImage indicates that there was an error during processing.
-    private let completionHandler: (UIImage?) -> ()
-
     /// Size of waveform image to render
     public let imageSize: CGSize
     
@@ -588,6 +585,9 @@ final public class FDWaveformRenderOperation: Operation {
     public override var isFinished: Bool { return _isFinished }
     
     // MARK: - Private
+    
+    ///  Handler called when the rendering has completed. nil UIImage indicates that there was an error during processing.
+    private let completionHandler: (UIImage?) -> ()
     
     /// Final rendered image. Used to hold image for completionHandler.
     private var renderedImage: UIImage?

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -34,7 +34,7 @@ open class FDWaveformView: UIView {
             FDAudioContext.load(fromAudioURL: audioURL) { audioContext in
                 DispatchQueue.main.async {
                     if audioContext == nil {
-                        NSLog("FDWaveformView failed to load URL")
+                        NSLog("FDWaveformView failed to load URL: \(audioURL)")
                     }
                     
                     self.audioContext = audioContext // This will reset the view and kick off a layout

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -289,7 +289,7 @@ open class FDWaveformView: UIView {
 
     override open func layoutSubviews() {
         super.layoutSubviews()
-        guard audioContext != nil && !renderingInProgress && zoomEndSamples > 0 else {
+        guard audioContext != nil && zoomEndSamples > 0 else {
             return
         }
 
@@ -320,10 +320,7 @@ open class FDWaveformView: UIView {
     }
 
     func renderWaveform() {
-        guard
-            !renderingInProgress,
-            let audioContext = audioContext
-            else { return }
+        guard let audioContext = audioContext else { return }
 
         print("rendering")
         

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -207,7 +207,6 @@ open class FDWaveformView: UIView {
     }
     
     /// Represents the status of the waveform renderings
-    // TODO: update names?
     private enum CacheStatus {
         case dirty
         case notDirty(cancelInProgressRenderOperation: Bool)

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -683,8 +683,6 @@ final public class FDWaveformRenderOperation: Operation {
             return nil
         }
         
-        UIGraphicsEndImageContext()
-        
         return image
     }
 }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -148,6 +148,7 @@ open class FDWaveformView: UIView {
             zoomStartSamples = 0
             zoomEndSamples = totalSamples
             waveformRenderOperation = nil
+            renderForCurrentAssetFailed = false
             
             setNeedsDisplay()
             setNeedsLayout()
@@ -160,7 +161,6 @@ open class FDWaveformView: UIView {
             if newValue !== waveformRenderOperation {
                 print("cancelling")
                 waveformRenderOperation?.cancel()
-                renderForCurrentAssetFailed = false
             }
         }
     }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -442,6 +442,7 @@ final public class FDWaveformRenderTask {
     
     public func start() {
         // TODO: needed if we go to nsoperation?
+        // TODO: if there is an error running this, then the waveformview will try to load the image over and over
         if #available(iOS 8.0, *) {
             DispatchQueue.global(qos: .background).async { self.render() }
         } else {

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -174,6 +174,7 @@ open class FDWaveformView: UIView {
         }
     }
     
+    /// Desired scale of image based on window's screen scale
     private var desiredImageScale: CGFloat {
         return window?.screen.scale ?? UIScreen.main.scale
     }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -541,13 +541,13 @@ public enum FDWaveformType: Equatable {
 public struct FDWaveformRenderFormat {
 
     /// The type of waveform to render
-    public var type: FDWaveformType = .linear
+    public var type: FDWaveformType
     
     /// The color of the waveform
-    public var wavesColor = UIColor.black
+    public var wavesColor: UIColor
     
     /// The scale factor to apply to the rendered image (usually the current screen's scale)
-    public var scale: CGFloat = UIScreen.main.scale
+    public var scale: CGFloat
     
     /// Whether the resulting image size should be as close as possible to imageSize (approximate)
     /// or whether it should match it exactly. Right now there is no support for matching exactly.
@@ -555,6 +555,20 @@ public struct FDWaveformRenderFormat {
     //       Right now the imageSize passed in to the render operation might not match the
     //       resulting image's size. This flag is hard coded here to convey that.
     public let constrainImageSizeToExactlyMatch = false
+    
+    // To make these public, you must implement them
+    // See http://stackoverflow.com/questions/26224693/how-can-i-make-public-by-default-the-member-wise-initialiser-for-structs-in-swif
+    public init() {
+        self.init(type: .linear,
+                  wavesColor: .black,
+                  scale: UIScreen.main.scale)
+    }
+    
+    public init(type: FDWaveformType, wavesColor: UIColor, scale: CGFloat) {
+        self.type = type
+        self.wavesColor = wavesColor
+        self.scale = scale
+    }
 }
 
 /// Operation used for rendering waveform images

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -550,6 +550,13 @@ public struct FDWaveformRenderFormat {
     
     /// The scale factor to apply to the rendered image (usually the current screen's scale)
     public var scale: CGFloat = UIScreen.main.scale
+    
+    /// Whether the resulting image size should be as close as possible to imageSize (approximate)
+    /// or whether it should match it exactly. Right now there is no support for matching exactly.
+    // TODO: Support rendering operations that always match the desired imageSize passed in.
+    //       Right now the imageSize passed in to the render operation might not match the
+    //       resulting image's size. This flag is hard coded here to convey that.
+    public let constrainImageSizeToExactlyMatch = false
 }
 
 /// Operation used for rendering waveform images

--- a/Tests/FDWaveformViewTests.swift
+++ b/Tests/FDWaveformViewTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 class FDWaveformViewTests: XCTestCase {
 
-    var fd: FDWaveformView!
+    var waveformView: FDWaveformView!
 
     override func setUp() {
         super.setUp()
-        fd = FDWaveformView()
+        waveformView = FDWaveformView()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
@@ -31,23 +31,23 @@ class FDWaveformViewTests: XCTestCase {
     }
 
     func testFD() {
-        XCTAssert(fd != nil)
+        XCTAssert(waveformView != nil)
     }
 
     func testZoomSaples() {
-        XCTAssert(fd.zoomStartSamples == 0)
-        XCTAssert(fd.zoomEndSamples == 0)
+        XCTAssert(waveformView.zoomStartSamples == 0)
+        XCTAssert(waveformView.zoomEndSamples == 0)
     }
 
     func testGesturesPermissions() {
-        XCTAssert(fd.doesAllowScroll == true)
-        XCTAssert(fd.doesAllowStretch == true)
-        XCTAssert(fd.doesAllowScrubbing == true)
+        XCTAssert(waveformView.doesAllowScroll == true)
+        XCTAssert(waveformView.doesAllowStretch == true)
+        XCTAssert(waveformView.doesAllowScrubbing == true)
     }
 
     func testColors() {
-        XCTAssert(fd.wavesColor == UIColor.black)
-        XCTAssert(fd.progressColor == UIColor.blue)
+        XCTAssert(waveformView.wavesColor == UIColor.black)
+        XCTAssert(waveformView.progressColor == UIColor.blue)
     }
 
 }

--- a/Tests/FDWaveformViewTests.swift
+++ b/Tests/FDWaveformViewTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class FDWaveformViewTests: XCTestCase {
 
-    var fd: FDWaveformView?
+    var fd: FDWaveformView!
 
     override func setUp() {
         super.setUp()
@@ -35,19 +35,19 @@ class FDWaveformViewTests: XCTestCase {
     }
 
     func testZoomSaples() {
-        XCTAssert(fd?.zoomStartSamples == 0)
-        XCTAssert(fd?.zoomEndSamples == 0)
+        XCTAssert(fd.zoomStartSamples == 0)
+        XCTAssert(fd.zoomEndSamples == 0)
     }
 
     func testGesturesPermissions() {
-        XCTAssert(fd?.doesAllowScroll == true)
-        XCTAssert(fd?.doesAllowStretch == true)
-        XCTAssert(fd?.doesAllowScrubbing == true)
+        XCTAssert(fd.doesAllowScroll == true)
+        XCTAssert(fd.doesAllowStretch == true)
+        XCTAssert(fd.doesAllowScrubbing == true)
     }
 
     func testColors() {
-        XCTAssert(fd?.wavesColor == UIColor.black)
-        XCTAssert(fd?.progressColor == UIColor.blue)
+        XCTAssert(fd.wavesColor == UIColor.black)
+        XCTAssert(fd.progressColor == UIColor.blue)
     }
 
 }

--- a/Tests/FDWaveformViewTests.swift
+++ b/Tests/FDWaveformViewTests.swift
@@ -16,24 +16,14 @@ class FDWaveformViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
         waveformView = FDWaveformView()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
 
-    func testExample() {
-        XCTAssert(true)
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testFD() {
-        XCTAssert(waveformView != nil)
-    }
-
+    // MARK: - Tests
+    
     func testZoomSaples() {
         XCTAssert(waveformView.zoomStartSamples == 0)
         XCTAssert(waveformView.zoomEndSamples == 0)


### PR DESCRIPTION
- Added support for rendering waveform images outside of a view (See `FDWaveformRenderOperation`)
- Added support for rendering linear waveforms
- Added support for changing `wavesColor` and `progressColor` after waveform was rendered
- Added support for updating waveform type and color to iOS Example app.
- Fixed bug which could prevent waveform from fitting new view size if rendering was in progress during a view resize
- Fixed bug which caused `waveformViewDidLoad()` to not be called after the audio file was loaded
- Fixed bug which caused subsequent waveform renderings for new audioURLs to never complete if there was an error with a previous render
- Fixed bug which could cause a crash (divide by zero error) if the view's width was 0